### PR TITLE
Fix: dotenv heroku config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_HOST=

--- a/webpack.config.base.js
+++ b/webpack.config.base.js
@@ -19,7 +19,9 @@ module.exports = {
     publicPath: '/',
   },
   plugins: [
-    new Dotenv(),
+    new Dotenv({
+      systemvars: true,
+    }),
     new HtmlWebPackPlugin({
       template: './public/index.html',
       filename: './index.html',


### PR DESCRIPTION
## Description

This PR adds `systemvars: true` to the `Dotenv` in the webpack to fix the `Heroku` deploy.